### PR TITLE
WIP: Add a simple integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 lib
+bundle.js
+example.css.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@
 .editorconfig
 jsconfig.json
 src
+test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "pretest": "rm -f ./test/example.css.d.ts && touch ./test/example.css.d.ts",
+    "test": "babel-node ./node_modules/webpack/bin/webpack --config ./test/webpack.config.babel.js && diff ./test/example.css.d.ts ./test/expected-example.css.d.ts"
   },
   "author": "Tim Sebastian <tim.sebastian@gmail.com>",
   "license": "MIT",
@@ -26,10 +28,16 @@
   "devDependencies": {
     "babel-cli": "6.10.1",
     "babel-eslint": "6.1.0",
+    "babel-loader": "^6.2.5",
+    "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-stage-0": "6.5.0",
+    "css-loader": "^0.24.0",
     "eslint": "2.13.1",
-    "eslint-plugin-babel": "3.3.0"
+    "eslint-plugin-babel": "3.3.0",
+    "ts-loader": "^0.8.2",
+    "typescript": "^1.8.10",
+    "webpack": "^1.13.2"
   },
   "repository": {
     "type": "git",

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -1,0 +1,4 @@
+import styles from './example.css';
+
+const foo = styles.foo;
+const barBaz = styles['bar-baz'];

--- a/test/example.css
+++ b/test/example.css
@@ -1,0 +1,7 @@
+.foo {
+  color: white;
+}
+
+.bar-baz {
+  color: green;
+}

--- a/test/expected-example.css.d.ts
+++ b/test/expected-example.css.d.ts
@@ -1,0 +1,7 @@
+export interface IExampleCss {
+  'foo': string;
+  'bar-baz': string;
+}
+declare const styles: IExampleCss;
+
+export default styles;

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "noImplicitAny": true
+    }
+}

--- a/test/webpack.config.babel.js
+++ b/test/webpack.config.babel.js
@@ -1,0 +1,16 @@
+import TypingsCssModulePlugin from '../src/';
+
+module.exports = {
+  entry: './test/entry.ts',
+  output: {
+    path: __dirname,
+    filename: 'bundle.js'
+  },
+  module: {
+    loaders: [
+      { test: /\.ts$/, loaders: ['babel', 'ts'] },
+      { test: /\.css$/, loader: 'css?modules' }
+    ]
+  },
+  plugins: [new TypingsCssModulePlugin()]
+};


### PR DESCRIPTION
Maybe this could be useful for tackling the current issues.
- FIXME: babel-polyfill has to be included (via babel-node) because of
  async/await usage (use promises instead)
- FIXME: The ts loader throws an error (currently irrelevant for the
  test result) because the d.ts file is created too late.

Please take a look, @timse.
